### PR TITLE
I-OSS 프로젝트 1.4.8 version 출시

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'inha'
-version = '1.4.7'
+version = '1.4.8'
 
 java {
 	toolchain {

--- a/src/main/java/inha/git/common/code/status/ErrorStatus.java
+++ b/src/main/java/inha/git/common/code/status/ErrorStatus.java
@@ -74,7 +74,7 @@ public enum ErrorStatus implements BaseErrorCode {
     FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "FILE4002", "파일을 찾을 수 없습니다."),
     FILE_NOT_ZIP(HttpStatus.BAD_REQUEST, "FILE4003", "zip 파일만 업로드 가능합니다."),
     FILE_MAX_FILES(HttpStatus.BAD_REQUEST, "FILE4004", "압축 파일 내의 파일 수는 100개 이하로 제한됩니다."),
-    FILE_MAX_SIZE(HttpStatus.BAD_REQUEST, "FILE4005", "압축 파일의 총 크기는 20MB 이하로 제한됩니다."),
+    FILE_MAX_SIZE(HttpStatus.BAD_REQUEST, "FILE4005", "압축 파일의 총 크기는 80MB 이하로 제한됩니다."),
     FILE_DELETE_FAIL(HttpStatus.BAD_REQUEST, "FILE4006", "파일 삭제에 실패하였습니다."),
     FILE_COMPRESS_FAIL(HttpStatus.BAD_REQUEST, "FILE4007", "파일 압축에 실패하였습니다."),
     FILE_INVALID_TYPE(HttpStatus.BAD_REQUEST, "FILE4008", "지원하지 않는 파일 형식입니다."),

--- a/src/main/java/inha/git/utils/file/ValidFile.java
+++ b/src/main/java/inha/git/utils/file/ValidFile.java
@@ -24,9 +24,9 @@ import static inha.git.common.code.status.ErrorStatus.*;
 @Slf4j
 public class ValidFile {
 
-    private static final long MAX_SIZE_MB = 20;
-    private static final long MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
-    private static final Set<String> ALLOWED_CONTENT_TYPES = new HashSet<>();
+    public static final long MAX_SIZE_MB = 80;
+    public static final long MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
+    public static final Set<String> ALLOWED_CONTENT_TYPES = new HashSet<>();
 
     static {
         ALLOWED_CONTENT_TYPES.add("application/zip");


### PR DESCRIPTION
I-OSS 프로젝트 1.4.8 version 출시

## 🐶 What Did You Do

이번 1.4.78 릴리즈에는 다음과 같은 주요 기능이 포함되었습니다:

- [x] 업로드 파일 용량 20MB -> 80MB로 확대

## ✨ etc
ex) 참고 레퍼런스, 코드리뷰에 하고싶은 말